### PR TITLE
Always use ticker symbol

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -385,7 +385,7 @@ class OfxConverter(Converter):
         if hasattr(pos, 'date') and hasattr(pos, 'security') and \
            hasattr(pos, 'unit_price'):
             dateStr = pos.date.strftime("%Y/%m/%d %H:%M:%S")
-            return "P %s %s %s\n" % (dateStr, pos.security, pos.unit_price)
+            return "P %s %s %s\n" % (dateStr, self.maybe_get_ticker(pos.security), pos.unit_price)
 
 
 class CsvConverter(Converter):

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -198,7 +198,6 @@ class OfxConverter(Converter):
         else:
             self.security_list = SecurityList([])
 
-            self.acctid = ofx.account.account_id
         if fid is not None:
             self.fid = fid
         else:

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -277,6 +277,15 @@ class OfxConverter(Converter):
         else:
             return ""
 
+    # Return the ticker symbol of the security with CUSIP, if it exists in the
+    # security_list mapping. Otherwise, simply return the CUSIP.
+    def maybe_get_ticker(self, cusip):
+        security = self.security_list.find_cusip(cusip)
+        if security is not None:
+            return security.ticker
+        else:
+            return cusip
+
     def convert(self, txn):
         """
         Convert an OFX Transaction to a posting
@@ -308,10 +317,7 @@ class OfxConverter(Converter):
 
             metadata = {"ofxid": ofxid}
 
-            security = txn.security
-            new_security = self.security_list.find_cusip(txn.security)
-            if new_security is not None:
-                security = new_security.ticker
+            security = self.maybe_get_ticker(txn.security)
 
             if isinstance(txn.type, str):
                 # recent versions of ofxparse

--- a/tests/test_ofx_formatter.py
+++ b/tests/test_ofx_formatter.py
@@ -70,14 +70,14 @@ class TestOfxConverter(LedgerTestCase):
         self.assertEqualLedgerPosting(converter.convert(ofx.account.statement.transactions[0]).format(),
 """2012/07/20 YOU BOUGHT
   ; ofxid: 7776.01234567890.0123456789020201120120720
-  Foo  100.00000 "458140100" @ $25.635000000
+  Foo  100.00000 INTC @ $25.635000000
   Assets:Unknown  -$2563.50
 """)
         # test no payee/memo
         self.assertEqualLedgerPosting(converter.convert(ofx.account.statement.transactions[1]).format(),
 """2012/07/27 Foo: buystock
   ; ofxid: 7776.01234567890.0123456789020901120120727
-  Foo  128.00000 "G7945E105" @ $39.390900000
+  Foo  128.00000 SDRL @ $39.390900000
   Assets:Unknown  -$5042.04
 """)
 
@@ -129,7 +129,7 @@ class TestOfxConverter(LedgerTestCase):
         self.assertEqualLedgerPosting(converter.convert(ofx.account.statement.transactions[0]).format(),
 """2012/07/20 YOU BOUGHT
   ; ofxid: 7776.01234567890.0123456789020201120120720
-  Foo  100.00000 "458140100" @ $25.635000000
+  Foo  100.00000 INTC @ $25.635000000
   Assets:Unknown  -$2563.50
 """)
 

--- a/tests/test_ofx_formatter.py
+++ b/tests/test_ofx_formatter.py
@@ -158,11 +158,11 @@ class TestOfxConverter(LedgerTestCase):
 
 
     def test_position(self):
-        ofx = OfxParser.parse(file(os.path.join('fixtures', 'investment_401k.ofx')))
+        ofx = OfxParser.parse(file(os.path.join('fixtures', 'cusip.ofx')))
         converter = OfxConverter(ofx=ofx, name="Foo", indent=4,
                                  unknownaccount='Expenses:Unknown')
         self.assertEqual(converter.format_position(ofx.account.statement.positions[0]),
-                         """P 2014/06/30 06:00:00 FOO 22.517211
+                         """P 2016/10/08 07:30:08 SHSAX 47.8600000
 """)
 
     def test_dividend(self):


### PR DESCRIPTION
- Move CUSIP to ticker mapping to OfxConverter
- Always use ticker symbol if available