### PR TITLE
clean_id: clean *,[,] characters

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -163,7 +163,10 @@ class Converter(object):
         return id.replace('/', '_').\
             replace('$', '_').\
             replace(' ', '_').\
-            replace('@', '_')
+            replace('@', '_').\
+            replace('*', '_').\
+            replace('[', '_').\
+            replace(']', '_')
 
     def __init__(self, ledger=None, unknownaccount=None, currency='$', indent=4):
         self.lgr = ledger


### PR DESCRIPTION
The characters *,[,] may show up as a transaction id, and confuse Ledger
into trying to match it as a regex.

An example of an OFX `FITID` that caused problems:

```
<FITID>20160101000000[-6:CST]*5.44*513**POS Return THE HOME DEPOT 803
```