### PR TITLE
Some small dependency bounds revisions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     install_requires=[
         'setuptools>=28.8',
         'ofxclient',
-        'ofxparse>=0.15',
+        'ofxparse>=0.14',
         'BeautifulSoup4',
         'fuzzywuzzy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
     install_requires=[
-        'setuptools>=28.8',
+        'setuptools>=26',
         'ofxclient',
         'ofxparse>=0.14',
         'BeautifulSoup4',


### PR DESCRIPTION
Fixes a small inconsistency between requirements.txt and setuptools, which makes packaging it in non-Python environments a bit easier.

Note that I haven't set up my environment to run all the tests (in particular all the tests testing Ledger's Python bindings fail out with "Ledger python interface not found!") so I don't know whether I'm breaking something here. I'll try to see if I can get time to run this soon, but I figured I'd put this up so that you could at least review and test on your own if you were interested in merging this in.