### PR TITLE
Adding support for --shorten-account and --hardcode-account

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -96,7 +96,8 @@ def sync(ledger, accounts, args):
                                          ledger=ledger,
                                          indent=args.indent,
                                          unknownaccount=args.unknownaccount,
-                                         payee_format=args.payee_format)
+                                         payee_format=args.payee_format,
+					 shortenaccount=args.shortenaccount)
                 print_results(converter, ofx, ledger, txns, args)
         except KeyboardInterrupt:
             raise
@@ -124,7 +125,9 @@ empty and no accountname supplied!")
                              indent=args.indent,
                              fid=args.fid,
                              unknownaccount=args.unknownaccount,
-                             payee_format=args.payee_format)
+                             payee_format=args.payee_format,
+                             hardcodeaccount=args.hardcodeaccount,
+                             shortenaccount=args.shortenaccount)
 
     print_results(converter, ofx, ledger, txns, args)
 
@@ -171,6 +174,12 @@ if importing from file, set account name for import')
     parser.add_argument('--fid', type=int, default=None,
                         help='pass in fid value for OFX files that do not \
 supply it')
+    parser.add_argument('--hardcode-account', type=int, default=None, dest='hardcodeaccount',
+                        help='pass in hardcoded account number for OFX files \
+to maintain ledger files without real account numbers')
+    parser.add_argument('--shorten-account', default=False, action='store_true', dest='shortenaccount',
+                        help='shorten all account numbers to last 4 digits \
+to maintain ledger files without full account numbers')
     parser.add_argument('--unknown-account', type=str, dest='unknownaccount',
                         default=None,
                         help='specify account name to use when one can\'t be \

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -85,7 +85,7 @@ def print_results(converter, ofx, ledger, txns, args):
             print converter.format_position(pos)
 
 def sync(ledger, accounts, args):
-    sync = OfxSynchronizer(ledger)
+    sync = OfxSynchronizer(ledger, shortenaccount=args.shortenaccount)
     for acct in accounts:
         try:
             (ofx, txns) = sync.get_new_txns(acct, resync=args.resync,
@@ -108,7 +108,8 @@ def sync(ledger, accounts, args):
 
 
 def import_ofx(ledger, args):
-    sync = OfxSynchronizer(ledger)
+    sync = OfxSynchronizer(ledger, hardcodeaccount=args.hardcodeaccount, 
+                                   shortenaccount=args.shortenaccount)
     (ofx, txns) = sync.parse_file(args.PATH)
     accountname = args.account
     if accountname is None:

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -97,7 +97,7 @@ def sync(ledger, accounts, args):
                                          indent=args.indent,
                                          unknownaccount=args.unknownaccount,
                                          payee_format=args.payee_format,
-					 shortenaccount=args.shortenaccount)
+                                         shortenaccount=args.shortenaccount)
                 print_results(converter, ofx, ledger, txns, args)
         except KeyboardInterrupt:
             raise

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -174,7 +174,7 @@ if importing from file, set account name for import')
     parser.add_argument('--fid', type=int, default=None,
                         help='pass in fid value for OFX files that do not \
 supply it')
-    parser.add_argument('--hardcode-account', type=int, default=None, dest='hardcodeaccount',
+    parser.add_argument('--hardcode-account', type=str, default=None, dest='hardcodeaccount',
                         help='pass in hardcoded account number for OFX files \
 to maintain ledger files without real account numbers')
     parser.add_argument('--shorten-account', default=False, action='store_true', dest='shortenaccount',

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -169,6 +169,7 @@ class Converter(object):
             replace(' ', '_').\
             replace('@', '_').\
             replace('*', '_').\
+            replace('+', '_').\
             replace('[', '_').\
             replace(']', '_')
 

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -195,20 +195,18 @@ class Converter(object):
 
 class OfxConverter(Converter):
     def __init__(self, ofx, name, indent=4, ledger=None, fid=None,
-                 unknownaccount=None, payee_format=None, hardcodeaccount=None, shortenaccount=None):
+                 unknownaccount=None, payee_format=None, hardcodeaccount=None, shortenaccount=False):
         super(OfxConverter, self).__init__(ledger=ledger,
                                            indent=indent,
                                            unknownaccount=unknownaccount,
                                            currency=ofx.account.statement.currency,
                                            payee_format=payee_format)
+        self.real_acctid = ofx.account.account_id
         if hardcodeaccount is not None:
-            self.real_acctid = ofx.account.account_id
             self.acctid = hardcodeaccount
         elif shortenaccount:
-            self.real_acctid = ofx.account.account_id
             self.acctid = ofx.account.account_id[-4:]
         else:
-            self.real_acctid = ofx.account.account_id
             self.acctid = ofx.account.account_id
         self.payee_format = payee_format
 

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -194,13 +194,18 @@ class Converter(object):
 
 class OfxConverter(Converter):
     def __init__(self, ofx, name, indent=4, ledger=None, fid=None,
-                 unknownaccount=None, payee_format=None):
+                 unknownaccount=None, payee_format=None, hardcodeaccount=None, shortenaccount=None):
         super(OfxConverter, self).__init__(ledger=ledger,
                                            indent=indent,
                                            unknownaccount=unknownaccount,
                                            currency=ofx.account.statement.currency,
                                            payee_format=payee_format)
-        self.acctid = ofx.account.account_id
+        if hardcodeaccount is not None:
+            self.acctid = hardcodeaccount
+        elif shortenaccount:
+            self.acctid = ofx.account.account_id[-4:]
+        else:
+            self.acctid = ofx.account.account_id
         self.payee_format = payee_format
 
         # build SecurityList (including indexing by CUSIP and ticker symbol)

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -201,10 +201,13 @@ class OfxConverter(Converter):
                                            currency=ofx.account.statement.currency,
                                            payee_format=payee_format)
         if hardcodeaccount is not None:
+            self.real_acctid = ofx.account.account_id
             self.acctid = hardcodeaccount
         elif shortenaccount:
+            self.real_acctid = ofx.account.account_id
             self.acctid = ofx.account.account_id[-4:]
         else:
+            self.real_acctid = ofx.account.account_id
             self.acctid = ofx.account.account_id
         self.payee_format = payee_format
 
@@ -225,6 +228,10 @@ class OfxConverter(Converter):
         self.name = name
 
     def mk_ofxid(self, txnid):
+        if self.acctid != self.real_acctid:
+            # Some banks insert the bank account number into the transaction ID
+            # We will do this to properly hide the account number for privacy reasons
+            txnid = txnid.replace(self.real_acctid, self.acctid)
         return Converter.clean_id("%s.%s.%s" % (self.fid, self.acctid, txnid))
 
     def format_payee(self, txn):

--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -47,13 +47,11 @@ class OfxSynchronizer(Synchronizer):
             txnid_to_use = txn.id
             if self.hardcodeaccount:
                 acctid_to_use = self.hardcodeaccount
-		print "replacing "+txnid_to_use+ " " +acctid + " "+acctid_to_use
                 txnid_to_use = txnid_to_use.replace(acctid, acctid_to_use)
             elif self.shortenaccount:
                 acctid_to_use = acctid[-4:]
                 txnid_to_use = txnid_to_use.replace(acctid, acctid_to_use)
             ofxid = "%s.%s" % (acctid_to_use, txnid_to_use)
-            print ofxid
             return self.lgr.check_transaction_by_id("ofxid", ofxid)
 
     # Filter out comment transactions. These have an amount of 0 and the same

--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -28,7 +28,9 @@ class Synchronizer(object):
         self.lgr = lgr
 
 class OfxSynchronizer(Synchronizer):
-    def __init__(self, lgr):
+    def __init__(self, lgr, hardcodeaccount=None, shortenaccount=None):
+        self.hardcodeaccount = hardcodeaccount
+        self.shortenaccount  = shortenaccount
         super(OfxSynchronizer, self).__init__(lgr)
 
     def parse_file(self, path, accountname=None):
@@ -41,7 +43,15 @@ class OfxSynchronizer(Synchronizer):
             # All transactions are considered "synced" in this case.
             return False
         else:
-            ofxid = "%s.%s" % (acctid, txn.id)
+            acctid_to_use = acctid
+            txnid_to_use = txn.id
+            if self.hardcodeaccount:
+                acctid_to_use = self.hardcodeaccount
+                txnid_to_use.replace(acctid, acctid_to_use)
+            elif self.shortenaccount:
+                acctid_to_use = acctid[-4:]
+                txnid_to_use.replace(acctid, acctid_to_use)
+            ofxid = "%s.%s" % (acctid_to_use, txnid_to_use)
             return self.lgr.check_transaction_by_id("ofxid", ofxid)
 
     # Filter out comment transactions. These have an amount of 0 and the same

--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -47,11 +47,13 @@ class OfxSynchronizer(Synchronizer):
             txnid_to_use = txn.id
             if self.hardcodeaccount:
                 acctid_to_use = self.hardcodeaccount
-                txnid_to_use.replace(acctid, acctid_to_use)
+		print "replacing "+txnid_to_use+ " " +acctid + " "+acctid_to_use
+                txnid_to_use = txnid_to_use.replace(acctid, acctid_to_use)
             elif self.shortenaccount:
                 acctid_to_use = acctid[-4:]
-                txnid_to_use.replace(acctid, acctid_to_use)
+                txnid_to_use = txnid_to_use.replace(acctid, acctid_to_use)
             ofxid = "%s.%s" % (acctid_to_use, txnid_to_use)
+            print ofxid
             return self.lgr.check_transaction_by_id("ofxid", ofxid)
 
     # Filter out comment transactions. These have an amount of 0 and the same

--- a/tests/test_ofx_formatter.py
+++ b/tests/test_ofx_formatter.py
@@ -64,6 +64,28 @@ class TestOfxConverter(LedgerTestCase):
     Expenses:Misc                                          -$0.01
 """)
 
+    def test_shortenaccount(self):
+        ofx = OfxParser.parse(file(os.path.join('fixtures', 'checking.ofx')))
+        converter = OfxConverter(ofx=ofx, name="Foo", indent=4, shortenaccount=True)
+        # testing indent, so do not use the string collapsing version of assert
+        self.assertEqual(converter.convert(ofx.account.statement.transactions[0]).format(),
+"""2011/03/31 DIVIDEND EARNED FOR PERIOD OF 03/01/2011 THROUGH 03/31/2011 ANNUAL PERCENTAGE YIELD EARNED IS 0.05%
+    Foo                                                     $0.01
+    ; ofxid: 1101.87~7.0000486
+    Expenses:Misc                                          -$0.01
+""")
+
+    def test_hardcodeaccount(self):
+        ofx = OfxParser.parse(file(os.path.join('fixtures', 'checking.ofx')))
+        converter = OfxConverter(ofx=ofx, name="Foo", indent=4, hardcodeaccount="9999")
+        # testing indent, so do not use the string collapsing version of assert
+        self.assertEqual(converter.convert(ofx.account.statement.transactions[0]).format(),
+"""2011/03/31 DIVIDEND EARNED FOR PERIOD OF 03/01/2011 THROUGH 03/31/2011 ANNUAL PERCENTAGE YIELD EARNED IS 0.05%
+    Foo                                                     $0.01
+    ; ofxid: 1101.9999.0000486
+    Expenses:Misc                                          -$0.01
+""")
+
     def test_investments(self):
         ofx = OfxParser.parse(file(os.path.join('fixtures', 'fidelity.ofx')))
         converter = OfxConverter(ofx=ofx, name="Foo")


### PR DESCRIPTION
Adding support for shortening account numbers to last 4 digits or overriding account numbers to provide account number privacy in ledger files and to provide easy transition when credit cards are reissued with new account numbers due to fraud.