### PR TITLE
Pass unknownaccount into csv parse_file and allow csv assertions

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -137,11 +137,12 @@ def import_csv(ledger, args):
         raise Exception("When importing a CSV file, you must specify an account name.")
     sync = CsvSynchronizer(ledger, payee_format=args.payee_format)
     accountname = args.account
-    txns = sync.parse_file(args.PATH, accountname=args.account)
+    txns = sync.parse_file(args.PATH, accountname=args.account,
+                            unknownaccount=args.unknownaccount)
     if args.reverse:
         txns = reversed(txns)
     for txn in txns:
-        print txn.format(args.indent)
+        print txn.format(args.indent, args.assertions)
 
 def load_plugins(config_dir):
     plugin_dir = os.path.join(config_dir, 'ledger-autosync', 'plugins')

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -104,7 +104,7 @@ class Transaction(object):
         self.metadata = metadata
         self.cleared = cleared
 
-    def format(self, indent=4):
+    def format(self, indent=4, assertions=False):
         retval = ""
         cleared_str = " "
         if self.cleared:
@@ -116,7 +116,7 @@ class Transaction(object):
         for k,v in self.metadata.iteritems():
             retval += "%s; %s: %s\n" % (" "*indent, k, v)
         for posting in self.postings:
-            retval += posting.format(indent)
+            retval += posting.format(indent, assertions)
         return retval
 
 class Posting(object):
@@ -127,13 +127,13 @@ class Posting(object):
         self.unit_price = unit_price
         self.metadata = metadata
 
-    def format(self, indent=4):
+    def format(self, indent=4, assertions=False):
         space_count = 65 - indent - len(self.account) - len(self.amount.format())
         if space_count < 2:
             space_count = 2
         retval = "%s%s%s%s" % (
             " " * indent, self.account, " "*space_count, self.amount.format())
-        if self.asserted is not None:
+        if assertions and self.asserted is not None:
             retval = "%s = %s"%(retval, self.asserted.format())
         if self.unit_price is not None:
             retval = "%s @ %s"%(retval, self.unit_price.format())

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -104,7 +104,7 @@ class Transaction(object):
         self.metadata = metadata
         self.cleared = cleared
 
-    def format(self, indent=4, assertions=False):
+    def format(self, indent=4, assertions=True):
         retval = ""
         cleared_str = " "
         if self.cleared:
@@ -127,7 +127,7 @@ class Posting(object):
         self.unit_price = unit_price
         self.metadata = metadata
 
-    def format(self, indent=4, assertions=False):
+    def format(self, indent=4, assertions=True):
         space_count = 65 - indent - len(self.account) - len(self.amount.format())
         if space_count < 2:
             space_count = 2


### PR DESCRIPTION
I had a use case for a csv converter plugin that I wanted to write that could use access to the `unknownaccount` arg.  This PR passes that in as well.  (arguably, to make my plugin a bit more generic, I may want a liabilitiesAccount, expenseAccount and assetAcount passed in, but I can work with this for now and think about that column to account mapping in the future).

The file also had balances, so I added an `asserted` value in the Transaction Posting in the `CsvConverter` and needed to adjust the format functions to honor `args.assertions` as appropriate.

I think one could argue that a '--assert-final' option might be useful to only include the last assertion in the set of Transactions, but I already changed more than one thing for a single PR.  

fwiw, I have not been able to get the nosetests to run in my environment, but we can see what CI says.