### PR TITLE
Print newlines when writing to stderr.

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -103,7 +103,7 @@ def sync(ledger, accounts, args):
         except KeyboardInterrupt:
             raise
         except:
-            sys.stderr.write("Caught exception processing %s" %
+            sys.stderr.write("Caught exception processing %s\n" %
                              (acct.description))
             traceback.print_exc(file=sys.stderr)
 
@@ -232,7 +232,7 @@ transactions')
     if ledger_file is None:
         sys.stderr.write("LEDGER_FILE environment variable not set, and no \
 .ledgerrc file found, and -l argument was not supplied: running with deduplication disabled. \
-All transactions will be printed!")
+All transactions will be printed!\n")
         ledger = None
     elif args.no_ledger:
         ledger = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,7 +101,7 @@ class CliTest():
         with patch('ledgerautosync.cli.find_ledger_file', return_value=None):
             with patch('sys.stderr', new_callable=StringIO) as mock_stdout:
                 run([], config)
-                self.assertEquals(mock_stdout.getvalue(), 'LEDGER_FILE environment variable not set, and no .ledgerrc file found, and -l argument was not supplied: running with deduplication disabled. All transactions will be printed!')
+                self.assertEquals(mock_stdout.getvalue(), 'LEDGER_FILE environment variable not set, and no .ledgerrc file found, and -l argument was not supplied: running with deduplication disabled. All transactions will be printed!\n')
 
 @attr('hledger')
 class TestCliHledger(TestCase, CliTest):


### PR DESCRIPTION
Calling sys.stder.write() does not automatically add newlines so we need
to include them ourselves.