### PR TITLE
Remove unused fuzzy account matching

### DIFF
--- a/ledgerautosync/ledgerwrap.py
+++ b/ledgerautosync/ledgerwrap.py
@@ -27,7 +27,6 @@ from threading import Thread
 from queue import Queue, Empty
 from ledgerautosync.converter import Converter
 import logging
-from fuzzywuzzy import process
 
 
 csv.register_dialect(
@@ -80,11 +79,6 @@ class MetaLedger(object):
     def get_account_by_payee(self, payee, exclude):
         self.load_payees()
         return self.filter_accounts(self.payees.get(payee, []), exclude)
-
-    def get_fuzzy_account_by_payee(self, payee, exclude):
-        self.load_payees()
-        fuzzed_payee = process.extractOne(payee, self.payees)[0]
-        return self.filter_accounts([fuzzed_payee], exclude)
 
     def __init__(self):
         self.payees = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ beautifulsoup4==4.6.0
 cffi==1.11.5
 cryptography==2.3
 entrypoints==0.2.3
-fuzzywuzzy==0.16.0
 idna==2.6
 jeepney==0.3.1
 keyring==12.2.0

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ setup(
         'setuptools>=26',
         'ofxclient',
         'ofxparse>=0.16',
-        'BeautifulSoup4',
-        'fuzzywuzzy'
+        'BeautifulSoup4'
     ],
 
     extras_require={


### PR DESCRIPTION
Tested with `python3 -m nose -a generic` on OSX.

Before removing, I did try using fuzzywuzzy on my ledger setup. First, the results
it returned were actually an array instead of a single entry like `get_account_by_payee`.
Second, the array results were very bad.