### PR TITLE
Assign self.lgr in CsvConverter

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -547,6 +547,7 @@ class CsvConverter(Converter):
             unknownaccount=None,
             payee_format=None):
         super(CsvConverter, self).__init__(
+            ledger=ledger,
             indent=indent,
             unknownaccount=unknownaccount,
             payee_format=payee_format)

--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -198,6 +198,7 @@ class CsvSynchronizer(Synchronizer):
             converter = CsvConverter.make_converter(
                 set(reader.fieldnames),
                 dialect,
+                ledger=self.lgr,
                 name=accountname,
                 unknownaccount=unknownaccount,
                 payee_format=self.payee_format)


### PR DESCRIPTION
Allows csv converter classes to talk to the ledger to fill in missing
fields based on historical data for instance.