### PR TITLE
converter: Strip out & in clean_ids

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -222,6 +222,7 @@ class Converter(object):
             replace('@', '_').\
             replace('*', '_').\
             replace('+', '_').\
+            replace('&', '_').\
             replace('[', '_').\
             replace(']', '_')
 


### PR DESCRIPTION
If left in then csvids with & in them never match, despite being the same exact string.

Sample csvid which does not match, leading to duplicate imports:
```
$ git grep '03_21_2019,-9.64,BOARD_&_BREW_-_SCRIPPS_SAN_DIEGO_CA'
ledger.ldg:    ; csvid: 03_21_2019,-9.64,BOARD_&_BREW_-_SCRIPPS_SAN_DIEGO_CA
ledger.ldg:    ; csvid: 03_21_2019,-9.64,BOARD_&_BREW_-_SCRIPPS_SAN_DIEGO_CA
```