### PR TITLE
Fixing _csv.Error: Could not determine delimiter

### DIFF
--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -188,7 +188,7 @@ class CsvSynchronizer(Synchronizer):
                 f.seek(0)
             else:
                 f.seek(3)
-            dialect = csv.Sniffer().sniff(f.read(1024))
+            dialect = csv.Sniffer().sniff(f.readline())
             if not(has_bom):
                 f.seek(0)
             else:


### PR DESCRIPTION
I was trying to write a plugin to import a custom CSV and encountered this ` _csv.Error: Could not determine delimiter` exception. It appears to be caused by feeding too much input to the CSV dialect sniffer (as explained in the [stackoverflow post here](https://stackoverflow.com/a/35757505))

Fix is attached in the PR.