### PR TITLE
Add vertical bar to characters to be cleaned when found in id

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -224,7 +224,8 @@ class Converter(object):
             replace('+', '_').\
             replace('&', '_').\
             replace('[', '_').\
-            replace(']', '_')
+            replace(']', '_').\
+            replace('|', '_')
 
     def __init__(
             self,


### PR DESCRIPTION
American Express (amex) recently changed the format they use for ofx account numbers to include a vertical bar character.  This PR adds it to the characters which are cleaned by `Converter.clean_id` so it doesn't interfere with searches.