### PR TITLE
Add Venmo csv converter

### DIFF
--- a/fixtures/venmo.csv
+++ b/fixtures/venmo.csv
@@ -1,0 +1,36 @@
+Username,ID,Datetime,Type,Status,Note,From,To,Amount (total),Amount (fee),Funding Source,Destination,Beginning Balance,Ending Balance,Statement Period Venmo Fees,Year to Date Venmo Fees,Disclaimer
+my_username,,,,,,,,,,,,"$0",,,,
+,1,2020-01-01T13:00:00,Charge,Complete,foobar charge positive,Me,Friend A,+ $73.01,,,Venmo balance,,,,,
+,2,2020-01-02T17:00:00,Payment,Complete,foobar payment positive,Friend B,My Name,+ $50.03,,,Venmo balance,,,,,
+,3,2020-01-03T20:00:00,Payment,Complete,foobar payment negative,Me,Friend A,- $12.01,,Venmo balance,,,,,,
+,4,2020-01-04T04:00:00,Charge,Complete,foobar charge negative,Friend B,Me,- $35.02,,Venmo balance,,,,,,
+,,,,,,,,,,,,,"$76.01",,,
+,,,,,,,,,,,,,,$0.00,,
+,,,,,,,,,,,,,,,$0.00,
+,,,,,,,,,,,,,,,,"In case of errors or questions about your
+        electronic transfers:
+        - Telephone us at 855-812-4430
+        - Write the Venmo Error Resolution Department at
+          222  W. Merchandise Plaza, Suite 800, Chicago, IL 60654; or
+        - Write to us through the Contact Us page
+          (https://help.venmo.com/hc/en-us/requests/new)
+        Contact us as soon as you can if you think your statement or
+        receipt is wrong or if you need more information about
+        a transfer on the statement or receipt. We must hear from
+        you no later than 60 days after we sent you the FIRST
+        statement on which the error or problem appeared.
+        1. Tell us your name and username or phone number.
+        2. Describe the error or the transfer you are unsure about,
+           and explain as clearly as you can why you believe it is
+           an error or why you need more information.
+        3. Tell us the dollar amount of the suspected error.
+        We will investigate your complaint and will correct any
+        error promptly. If we take more than 10 business days to do
+        this, we will credit your account for the amount you think
+        is in error, so that you will have the use of the money
+        during the time it takes us to complete our investigation.
+        In case of errors or questions about your transactions made
+        with your Venmo Mastercard, please consult your
+        Cardholder Agreement
+        (https://venmo.com/legal/bancorp-cardholder-agreement).
+        "


### PR DESCRIPTION
This is the plugin I've been using to handle Venmo statements.  Wanted to share so others can use but there's some work that's needed before it can be merged, namely:

- [ ] Assertions properly handled 
Right now it prints assertions regardless of the values of `args.assertions`.  At a glance it doesn't look like the `CsvConverter` and `import_csv` are designed to handle assertions. 
- [ ] Tests added 
- [ ] Documentation updated (readme, changelog)

Any feedback on best approach for assertions here or discussion of higher level changes that can be made to handle them is appreciated!  I'll add tests and update documentation once that is handled.