### PR TITLE
Add date_format arg to specify format string for dates

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -292,7 +292,7 @@ transactions')
                         help='specify config file for ofxclient')
     parser.add_argument('-y', '--date-format', type=str, default=None, dest="date_format",
                         help="""Format string to use for printing dates.
-                        See strftime for details on format string syntax. Default is "%Y/%m/%d".""")
+                        See strftime for details on format string syntax. Default is "%%Y/%%m/%%d".""")
     args = parser.parse_args(args)
     if sys.argv[0][-16:] == "hledger-autosync":
         args.hledger = True

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -92,7 +92,8 @@ def make_ofx_converter(account,
                        payee_format,
                        hardcodeaccount,
                        shortenaccount,
-                       security_list):
+                       security_list,
+                       date_format):
     klasses = OfxConverter.__subclasses__()
     if len(klasses) > 1:
         raise Exception("I found more than 1 OfxConverter subclass, but only "
@@ -108,7 +109,8 @@ def make_ofx_converter(account,
                           payee_format=payee_format,
                           hardcodeaccount=hardcodeaccount,
                           shortenaccount=shortenaccount,
-                          security_list=security_list)
+                          security_list=security_list,
+                          date_format=date_format)
     else:
         return OfxConverter(account=account,
                             name=name,
@@ -119,7 +121,8 @@ def make_ofx_converter(account,
                             payee_format=payee_format,
                             hardcodeaccount=hardcodeaccount,
                             shortenaccount=shortenaccount,
-                            security_list=security_list)
+                            security_list=security_list,
+                            date_format=date_format)
 
 def sync(ledger, accounts, args):
     sync = OfxSynchronizer(ledger, shortenaccount=args.shortenaccount)
@@ -137,7 +140,8 @@ def sync(ledger, accounts, args):
                                                payee_format=args.payee_format,
                                                hardcodeaccount=None,
                                                shortenaccount=args.shortenaccount,
-                                               security_list=SecurityList(ofx))
+                                               security_list=SecurityList(ofx),
+                                               date_format=args.date_format)
                 print_results(converter, ofx, ledger, txns, args)
         except KeyboardInterrupt:
             raise
@@ -174,7 +178,8 @@ def import_ofx(ledger, args):
                                    payee_format=args.payee_format,
                                    hardcodeaccount=args.hardcodeaccount,
                                    shortenaccount=args.shortenaccount,
-                                   security_list=security_list)
+                                   security_list=security_list,
+                                   date_format=args.date_format)
     print_results(converter, ofx, ledger, txns, args)
 
 
@@ -182,7 +187,7 @@ def import_csv(ledger, args):
     if args.account is None:
         raise Exception(
             "When importing a CSV file, you must specify an account name.")
-    sync = CsvSynchronizer(ledger, payee_format=args.payee_format)
+    sync = CsvSynchronizer(ledger, payee_format=args.payee_format, date_format=args.date_format)
     txns = sync.parse_file(args.PATH, accountname=args.account,
                            unknownaccount=args.unknownaccount)
     if args.reverse:
@@ -285,6 +290,9 @@ transactions')
                         help='print CSV transactions in reverse order')
     parser.add_argument('-o', '--ofxconfig', type=str, default=None,
                         help='specify config file for ofxclient')
+    parser.add_argument('-y', '--date-format', type=str, default=None, dest="date_format",
+                        help="""Format string to use for printing dates.
+                        See strftime for details on format string syntax. Default is "%Y/%m/%d".""")
     args = parser.parse_args(args)
     if sys.argv[0][-16:] == "hledger-autosync":
         args.hledger = True

--- a/ledgerautosync/sync.py
+++ b/ledgerautosync/sync.py
@@ -169,9 +169,10 @@ class OfxSynchronizer(Synchronizer):
 
 
 class CsvSynchronizer(Synchronizer):
-    def __init__(self, lgr, payee_format=None):
+    def __init__(self, lgr, payee_format=None, date_format=None):
         super(CsvSynchronizer, self).__init__(lgr)
         self.payee_format = payee_format
+        self.date_format = date_format
 
     def is_row_synced(self, converter, row):
         if self.lgr is None:
@@ -202,7 +203,9 @@ class CsvSynchronizer(Synchronizer):
                 ledger=self.lgr,
                 name=accountname,
                 unknownaccount=unknownaccount,
-                payee_format=self.payee_format)
+                payee_format=self.payee_format,
+                date_format=self.date_format
+            )
             # Create a new reader in case the converter modified the dialect
             if not(has_bom):
                 f.seek(0)


### PR DESCRIPTION
Tested against `fixtures/checking.ofx` and `fixtures/paypal.csv` with:

```
fixtures/checking.ofx
fixtures/checking.ofx -y "%Y-%m-%d"
fixtures/paypal.csv -a "test"
fixtures/paypal.csv -y "%Y-%m-%d" -a "test"
```
