### PR TITLE
Limit payee lookup to actual accounts (Ledger)

### DIFF
--- a/ledgerautosync/ledgerwrap.py
+++ b/ledgerautosync/ledgerwrap.py
@@ -171,7 +171,7 @@ class Ledger(MetaLedger):
     def load_payees(self):
         if self.payees is None:
             self.payees = {}
-            r = self.run(["show"])
+            r = self.run(["show", "--actual"])
             for line in r:
                 self.add_payee(line[2], line[3])
 


### PR DESCRIPTION
This excludes accounts that are applied by automated transactions. Same fix as #77, applied to plain Ledger interface.  This should fix #56 for that interface, but might still need a fix for the
`LedgerPython` interface.