### PR TITLE
Fix ledger meta wildcard symbol (pourcent)

### DIFF
--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -235,7 +235,8 @@ class Converter(object):
             replace('&', '_').\
             replace('[', '_').\
             replace(']', '_').\
-            replace('|', '_')
+            replace('|', '_').\
+            replace('%', '_')
 
     def __init__(
             self,


### PR DESCRIPTION
When using ledger meta, the % symbol is used as a wildcard. So, it is
necessary to replace this symbol by a *underscore* symbol in order to
get an exact match.