### PR TITLE
Add --no-infer-account option to disable account inference

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -93,7 +93,8 @@ def make_ofx_converter(account,
                        hardcodeaccount,
                        shortenaccount,
                        security_list,
-                       date_format):
+                       date_format,
+                       infer_account):
     klasses = OfxConverter.__subclasses__()
     if len(klasses) > 1:
         raise Exception("I found more than 1 OfxConverter subclass, but only "
@@ -110,7 +111,8 @@ def make_ofx_converter(account,
                           hardcodeaccount=hardcodeaccount,
                           shortenaccount=shortenaccount,
                           security_list=security_list,
-                          date_format=date_format)
+                          date_format=date_format,
+                          infer_account=infer_account)
     else:
         return OfxConverter(account=account,
                             name=name,
@@ -122,7 +124,8 @@ def make_ofx_converter(account,
                             hardcodeaccount=hardcodeaccount,
                             shortenaccount=shortenaccount,
                             security_list=security_list,
-                            date_format=date_format)
+                            date_format=date_format,
+                            infer_account=infer_account)
 
 def sync(ledger, accounts, args):
     sync = OfxSynchronizer(ledger, shortenaccount=args.shortenaccount)
@@ -141,7 +144,8 @@ def sync(ledger, accounts, args):
                                                hardcodeaccount=None,
                                                shortenaccount=args.shortenaccount,
                                                security_list=SecurityList(ofx),
-                                               date_format=args.date_format)
+                                               date_format=args.date_format,
+                                               infer_account=args.infer_account)
                 print_results(converter, ofx, ledger, txns, args)
         except KeyboardInterrupt:
             raise
@@ -179,7 +183,8 @@ def import_ofx(ledger, args):
                                    hardcodeaccount=args.hardcodeaccount,
                                    shortenaccount=args.shortenaccount,
                                    security_list=security_list,
-                                   date_format=args.date_format)
+                                   date_format=args.date_format,
+                                   infer_account=args.infer_account)
     print_results(converter, ofx, ledger, txns, args)
 
 
@@ -293,6 +298,8 @@ transactions')
     parser.add_argument('-y', '--date-format', type=str, default=None, dest="date_format",
                         help="""Format string to use for printing dates.
                         See strftime for details on format string syntax. Default is "%%Y/%%m/%%d".""")
+    parser.add_argument('--no-infer-account', dest="infer_account", action='store_false', default=True,
+                        help='disable inference of offset account from payee')
     args = parser.parse_args(args)
     if sys.argv[0][-16:] == "hledger-autosync":
         args.hledger = True

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -245,7 +245,8 @@ class Converter(object):
             currency='$',
             indent=4,
             payee_format=None,
-            date_format=None):
+            date_format=None,
+            infer_account=True):
         self.lgr = ledger
         self.indent = indent
         self.unknownaccount = unknownaccount
@@ -254,9 +255,10 @@ class Converter(object):
         if self.currency == "USD":
             self.currency = "$"
         self.date_format = date_format
+        self.infer_account = infer_account
 
     def mk_dynamic_account(self, payee, exclude):
-        if self.lgr is None:
+        if self.lgr is None or not self.infer_account:
             return self.unknownaccount or 'Expenses:Misc'
         else:
             account = self.lgr.get_account_by_payee(payee, exclude)
@@ -280,13 +282,15 @@ class OfxConverter(Converter):
             shortenaccount=False,
             security_list=SecurityList(
             []),
-            date_format=None):
+            date_format=None,
+            infer_account=True):
         super(OfxConverter, self).__init__(ledger=ledger,
                                            indent=indent,
                                            unknownaccount=unknownaccount,
                                            currency=account.statement.currency,
                                            payee_format=payee_format,
-                                           date_format=date_format)
+                                           date_format=date_format,
+                                           infer_account=infer_account)
         self.real_acctid = account.account_id
         if hardcodeaccount is not None:
             self.acctid = hardcodeaccount
@@ -618,6 +622,7 @@ class CsvConverter(Converter):
             unknownaccount=None,
             payee_format=None,
             date_format=None,
+            infer_account=True,
     ):
         super(CsvConverter, self).__init__(
             ledger=ledger,
@@ -625,6 +630,7 @@ class CsvConverter(Converter):
             unknownaccount=unknownaccount,
             payee_format=payee_format,
             date_format=date_format,
+            infer_account=infer_account,
         )
         self.name = name
         self.dialect = dialect


### PR DESCRIPTION
This option disables the heuristic of determining the offset account
from the payee field.

fixes #118