### PR TITLE
#52  Add support for override the 

### DIFF
--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -71,7 +71,7 @@ def print_results(converter, ofx, ledger, txns, args):
                 not(ledger.check_transaction_by_id("ofxid", ALL_AUTOSYNC_INITIAL))):
             print(converter.format_initial_balance(ofx.account.statement))
     for txn in txns:
-        print(converter.convert(txn).format(args.indent, args.assertions, args.override_currency))
+        print(converter.convert(txn).format(args.indent, args.assertions))
     if args.assertions:
         print(converter.format_balance(ofx.account.statement))
 
@@ -94,7 +94,8 @@ def make_ofx_converter(account,
                        shortenaccount,
                        security_list,
                        date_format,
-                       infer_account):
+                       infer_account,
+                       currency):
     klasses = OfxConverter.__subclasses__()
     if len(klasses) > 1:
         raise Exception("I found more than 1 OfxConverter subclass, but only "
@@ -112,7 +113,8 @@ def make_ofx_converter(account,
                           shortenaccount=shortenaccount,
                           security_list=security_list,
                           date_format=date_format,
-                          infer_account=infer_account)
+                          infer_account=infer_account,
+                          currency=currency)
     else:
         return OfxConverter(account=account,
                             name=name,
@@ -125,7 +127,8 @@ def make_ofx_converter(account,
                             shortenaccount=shortenaccount,
                             security_list=security_list,
                             date_format=date_format,
-                            infer_account=infer_account)
+                            infer_account=infer_account,
+                            currency=currency)
 
 def sync(ledger, accounts, args):
     sync = OfxSynchronizer(ledger, shortenaccount=args.shortenaccount)
@@ -133,6 +136,11 @@ def sync(ledger, accounts, args):
         try:
             (ofx, txns) = sync.get_new_txns(acct, resync=args.resync,
                                             max_days=args.max)
+            if args.override_currency is None:
+                currency = ofx.account.statement.currency
+            else:
+                currency = args.override_currency
+
             if ofx is not None:
                 converter = make_ofx_converter(account=ofx.account,
                                                name=acct.description,
@@ -145,7 +153,8 @@ def sync(ledger, accounts, args):
                                                shortenaccount=args.shortenaccount,
                                                security_list=SecurityList(ofx),
                                                date_format=args.date_format,
-                                               infer_account=args.infer_account)
+                                               infer_account=args.infer_account,
+                                               currency=currency)
                 print_results(converter, ofx, ledger, txns, args)
         except KeyboardInterrupt:
             raise
@@ -170,6 +179,11 @@ def import_ofx(ledger, args):
         else:
             accountname = UNKNOWN_BANK_ACCOUNT
 
+    if args.override_currency is None:
+        currency=ofx.account.statement.currency
+    else:
+        currency = args.override_currency
+
     # build SecurityList (including indexing by CUSIP and ticker symbol)
     security_list = SecurityList(ofx)
 
@@ -184,7 +198,9 @@ def import_ofx(ledger, args):
                                    shortenaccount=args.shortenaccount,
                                    security_list=security_list,
                                    date_format=args.date_format,
-                                   infer_account=args.infer_account)
+                                   infer_account=args.infer_account,
+                                   currency=currency
+                                   )
     print_results(converter, ofx, ledger, txns, args)
 
 

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -71,7 +71,7 @@ def print_results(converter, ofx, ledger, txns, args):
                 not(ledger.check_transaction_by_id("ofxid", ALL_AUTOSYNC_INITIAL))):
             print(converter.format_initial_balance(ofx.account.statement))
     for txn in txns:
-        print(converter.convert(txn).format(args.indent))
+        print(converter.convert(txn).format(args.indent, args.assertions, args.override_currency))
     if args.assertions:
         print(converter.format_balance(ofx.account.statement))
 
@@ -242,6 +242,10 @@ if importing from file, set account name for import')
         help='do not de-duplicate against a ledger file')
     parser.add_argument('-i', '--indent', type=int, default=4,
                         help='number of spaces to use for indentation')
+    parser.add_argument('-c', '--override_currency', type=str, default=None,
+                        help='force currency of import, added as a postfix to \
+the amounts, unless it is one character in which case it goes at the front, \
+also allows for empty')
     parser.add_argument('--initial', action='store_true', default=False,
                         help='create initial balance entries')
     parser.add_argument('--fid', type=int, default=None,

--- a/ledgerautosync/cli.py
+++ b/ledgerautosync/cli.py
@@ -71,7 +71,7 @@ def print_results(converter, ofx, ledger, txns, args):
                 not(ledger.check_transaction_by_id("ofxid", ALL_AUTOSYNC_INITIAL))):
             print(converter.format_initial_balance(ofx.account.statement))
     for txn in txns:
-        print(converter.convert(txn).format(args.indent, args.assertions))
+        print(converter.convert(txn).format(args.indent))
     if args.assertions:
         print(converter.format_balance(ofx.account.statement))
 

--- a/ledgerautosync/converter.py
+++ b/ledgerautosync/converter.py
@@ -126,7 +126,7 @@ class Transaction(object):
         self.date_format = date_format
         self.checknum = checknum
 
-    def format(self, indent=4, assertions=True):
+    def format(self, indent=4, assertions=True, override_currency=None):
         retval = ""
         cleared_str = " "
         checknum_str = ""
@@ -145,7 +145,7 @@ class Transaction(object):
         for k in sorted(self.metadata.keys()):
             retval += "%s; %s: %s\n" % (" " * indent, k, self.metadata[k])
         for posting in self.postings:
-            retval += posting.format(indent, assertions)
+            retval += posting.format(indent, assertions, override_currency)
         return retval
 
 
@@ -163,7 +163,7 @@ class Posting(object):
         self.unit_price = unit_price
         self.metadata = metadata
 
-    def format(self, indent=4, assertions=True):
+    def format(self, indent=4, assertions=True, override_currency=None):
         space_count = 65 - indent - \
             len(self.account) - len(self.amount.format())
         if space_count < 2:
@@ -171,7 +171,7 @@ class Posting(object):
         retval = "%s%s%s%s" % (" " * indent,
                                self.account,
                                " " * space_count,
-                               self.amount.format())
+                               self.amount.format(override_currency))
         if assertions and self.asserted is not None:
             retval = "%s = %s" % (retval, self.asserted.format())
         if self.unit_price is not None:
@@ -195,13 +195,17 @@ class Amount(EasyEquality):
         self.unlimited = unlimited
         self.currency = currency
 
-    def format(self):
+    def format(self, override_currency=None):
         # Commodities must be quoted in ledger if they have
         # whitespace or numerals.
-        if re.search(r'[\s0-9]', self.currency):
-            currency = "\"%s\"" % (self.currency)
+        
+        if override_currency is None:
+            if re.search(r'[\s0-9]', self.currency):
+                currency = "\"%s\"" % (self.currency)
+            else:
+                currency = self.currency
         else:
-            currency = self.currency
+            currency = override_currency
         if self.unlimited:
             number = str(abs(self.number))
         else:
@@ -213,6 +217,9 @@ class Amount(EasyEquality):
         if len(currency) == 1:
             # $ comes before
             return "%s%s%s" % (prefix, currency, number)
+        elif len(currency) == 0:
+            return "%s%s" % (prefix, number)
+
         else:
             # USD comes after
             return "%s%s %s" % (prefix, number, currency)

--- a/tests/test_ofx_formatter.py
+++ b/tests/test_ofx_formatter.py
@@ -74,6 +74,20 @@ class TestOfxConverter(LedgerTestCase):
     Expenses:Misc                                          -$0.01
 """)
 
+    def test_override_currency(self):
+        with open(os.path.join('fixtures', 'checking.ofx'), 'rb') as ofx_file:
+            ofx = OfxParser.parse(ofx_file)
+        converter = OfxConverter(account=ofx.account, name="Foo", indent=4, override_currency="CAD")
+        # testing override_currency
+        self.assertEqual(
+            converter.convert(
+                ofx.account.statement.transactions[0]).format(),
+            """2011/03/31 DIVIDEND EARNED FOR PERIOD OF 03/01/2011 THROUGH 03/31/2011 ANNUAL PERCENTAGE YIELD EARNED IS 0.05%
+    Foo                                                     0.01 CAD
+    ; ofxid: 1101.1452687~7.0000486
+    Expenses:Misc                                          -0.01 CAD
+""")
+
     def test_shortenaccount(self):
         with open(os.path.join('fixtures', 'checking.ofx'), 'rb') as ofx_file:
             ofx = OfxParser.parse(ofx_file)


### PR DESCRIPTION
Having a go at issue #52 

Adds a command line parameter --override_currency="YOUR_CURRENCY"  which is then set as the currency for the print out.  It also supports --override_currency="" which is my use case, where all my entries to date simply don't have a currency and that's the way I like them.

I think this is roughly following the conventions for how you've got for new code.  I tried to write up a test, but the truth is I haven't been able to successfully run the test suite on my local machine, so I'm not sure if it'll pass although I think it looks about right... 